### PR TITLE
Check if tweet is functionally useless

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -106,7 +106,6 @@ function getDistinctTwitterLinksInContent(msgContent) {
 
 function isTextCloseToEnglish(text) {
   let topMatches = lngDetector.detect(text, config.translation.numberOfLanguages)
-  console.log(topMatches)
   for (const item of topMatches) {
     if ( item[0] === 'en' ) {
       logger.debug(`Text matched english with a score of ${item[1]}`)


### PR DESCRIPTION
This is a bit of a dumb attempt at isolating potentially dumb tweets (ones that only contain mentions and emojis). It probably won't work in this iteration but we will give it a damn good try.